### PR TITLE
Added open graph metadatasupport to web module

### DIFF
--- a/.ocamlinit
+++ b/.ocamlinit
@@ -11,3 +11,6 @@
 #directory "_build/src/core";;
 #load "calculon.cma";;
 module C = Calculon;;
+#directory "_build/src/web";;
+#load "calculon_web.cma";;
+module CW = Calculon_web;;

--- a/_oasis
+++ b/_oasis
@@ -35,6 +35,5 @@ Library "calculon_web"
   Pack:             true
   FindlibName:      web
   FindlibParent:    calculon
-  Modules:          Plugin_web, Plugin_movie, Movie_j, Movie_t, Movie_schema
+  Modules:          Plugin_web, Plugin_movie, Movie_j, Movie_t, Movie_schema, Og
   BuildDepends:     calculon, atdgen, cohttp, lwt, cohttp.lwt, lambdasoup, uri
-

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: 67de91ac76b323dc720b3e1be57b4c58)
+# DO NOT EDIT (digest: 066d7dd3b9d3000e7d7e274c002cae8f)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -44,6 +44,7 @@ true: annot, bin_annot
 "src/web/movie_j.cmx": for-pack(Calculon_web)
 "src/web/movie_t.cmx": for-pack(Calculon_web)
 "src/web/movie_schema.cmx": for-pack(Calculon_web)
+"src/web/og.cmx": for-pack(Calculon_web)
 <src/web/*.ml{,i,y}>: package(ISO8601)
 <src/web/*.ml{,i,y}>: package(atdgen)
 <src/web/*.ml{,i,y}>: package(cohttp)

--- a/src/web/calculon_web.mldylib
+++ b/src/web/calculon_web.mldylib
@@ -1,4 +1,4 @@
 # OASIS_START
 # DO NOT EDIT (digest: 8f34511291ee3252f2f6b354ded12daf)
-Calculon_web
-# OASIS_STOP
+  Calculon_web
+  # OASIS_STOP

--- a/src/web/calculon_web.mllib
+++ b/src/web/calculon_web.mllib
@@ -1,4 +1,4 @@
 # OASIS_START
 # DO NOT EDIT (digest: 8f34511291ee3252f2f6b354ded12daf)
-Calculon_web
-# OASIS_STOP
+  Calculon_web
+  # OASIS_STOP

--- a/src/web/calculon_web.mlpack
+++ b/src/web/calculon_web.mlpack
@@ -1,8 +1,9 @@
 # OASIS_START
-# DO NOT EDIT (digest: b6368067847a5c267854a6f122cb2fa3)
-Plugin_web
-Plugin_movie
-Movie_j
-Movie_t
-Movie_schema
-# OASIS_STOP
+# DO NOT EDIT (digest: 764bf17a04a4c576260204417d7e03c3)
+  Plugin_web
+  Plugin_movie
+  Movie_j
+  Movie_t
+  Movie_schema
+  Og
+  # OASIS_STOP

--- a/src/web/og.ml
+++ b/src/web/og.ml
@@ -1,0 +1,164 @@
+(** These data-structures are for holding meta-data
+    expressed by the {{:http://ogp.me/}graph protocol}.
+*)
+
+type url = { name : string }
+
+type locale = { language : string; territory : string }
+
+type og_type = TMusic | TVideo | TWebsite |
+               TArticle | TBook | TProfile | TOther of string
+
+type og_determiner = A | An | The | NoDet | Auto
+
+type og_video_metadata =
+  | VTag of string
+  | VDuration of int
+
+type og_metadata =
+  | Title of string | Type of og_type | Image of url | Url of url
+  | Audio of url | Description of string | Determiner of og_determiner
+  | Locale of locale | AlternateLocale of locale | SiteName of string
+  | Video of url | VideoMeta of og_video_metadata | UnparsedMeta of string
+
+type basic_metadata = { og_title : string;
+                        og_type  : og_type;
+                        og_image : url;
+                        og_url   : url;
+                      }
+
+let parse_type = function
+  | "video" -> TVideo
+  | "music" -> TMusic
+  (* TODO: add more types / subtypes *)
+  | str -> TOther str
+
+let parse_url str = Some { name = str }
+
+let parse_locale str =
+  match Str.split (Str.regexp "_") str with
+  | language :: territory :: _ -> Some { language; territory }
+  | _ -> None
+
+let make_title str = Title str
+let make_type t = Type t
+let make_image url = Image url
+let make_audio url = Audio url
+let make_description str =  Description str
+let make_determiner det = Determiner det
+let make_locale l = Locale l
+let make_alternate_locale l = AlternateLocale l
+let make_site_name str = SiteName str
+let make_video url = Video url
+let make_video_metadata meta = VideoMeta meta
+let make_url url = Url url
+
+let make_video_tag tag = VTag tag
+let make_video_duration dur = VDuration dur
+
+let format_url formatter { name } =
+  Format.fprintf formatter "%s" name
+
+let format_locale formatter { language; territory } =
+  Format.fprintf formatter "%s_%s" language territory
+
+let format_determiner formatter = function
+  | A     -> Format.fprintf formatter "a"
+  | An    -> Format.fprintf formatter "an"
+  | The   -> Format.fprintf formatter "the"
+  | NoDet -> Format.fprintf formatter ""
+  | Auto  -> Format.fprintf formatter ""
+
+let format_type formatter t =
+  let str = match t with
+    | TMusic -> "music"
+    | TVideo -> "video"
+    | TWebsite -> "website"
+    | TArticle -> "article"
+    | TBook -> "book"
+    | TProfile -> "profile"
+    | TOther str -> "other:"^str
+  in Format.fprintf formatter "%s" str
+
+
+let format_video_metadata formatter = function
+  | VTag tag -> Format.fprintf formatter "tag: %s" tag
+  | VDuration dur -> Format.fprintf formatter "duration: %d s" dur
+
+let format_metadata formatter = function
+  | Title t ->
+    Format.fprintf formatter "Title: %s" t
+  | Type t ->
+    Format.fprintf formatter "Type: %a" format_type t
+  | Image url ->
+    Format.fprintf formatter "Image: %a" format_url url
+  | Url url ->
+    Format.fprintf formatter "Url: %a" format_url url
+  | Audio url ->
+    Format.fprintf formatter "Audio: %a" format_url url
+  | Description str  ->
+    Format.fprintf formatter "Description: %s" str
+  | Determiner og_determiner ->
+    Format.fprintf formatter "Determiner %a" format_determiner og_determiner
+  | Locale locale ->
+    Format.fprintf formatter "Locale: %a" format_locale locale
+  | AlternateLocale locale  ->
+    Format.fprintf formatter "Alternate Locale: %a" format_locale locale
+  | SiteName str  ->
+    Format.fprintf formatter "Site Name: %s" str
+  | Video url  ->
+    Format.fprintf formatter "Video: %a" format_url url
+  | VideoMeta meta ->
+    Format.fprintf formatter "Video %a" format_video_metadata meta
+  | UnparsedMeta name ->
+    Format.fprintf formatter "Unparsed tag: %s" name
+
+module Parser = struct
+  open Soup
+  let og_prefix = Str.regexp "^og:"
+
+  let og_parser list elem =
+    let prop constructor x list =
+      match attribute "content" x with
+      | None -> list
+      | Some str -> constructor str :: list
+    in
+    let optprop constructor x list =
+      match attribute "content" x with
+      | None -> list
+      | Some str -> match constructor str with
+        | Some elem -> elem :: list
+        | None -> list
+    in
+    let optparser parser constructor str =
+      match parser str with
+      | None -> None
+      | Some url -> Some (constructor url)
+    in
+    let purl = optparser parse_url in
+    let plocale = optparser parse_locale in
+    match attribute "property" elem with
+    | Some "og:title" -> prop make_title elem list
+    | Some "og:type" -> prop (fun x -> make_type (parse_type x)) elem list
+    | Some "og:image" -> optprop (purl make_image) elem list
+    | Some "og:url" -> optprop (purl make_url) elem list
+    | Some "og:audio" -> optprop (purl make_audio) elem list
+    | Some "og:description" -> prop make_description elem list
+    | Some "og:determiner" -> (Determiner Auto) :: list
+    | Some "og:locale" -> optprop (plocale make_locale) elem list
+    | Some "og:locale:alternate" -> optprop (plocale make_locale) elem list
+    | Some "og:site_name" -> prop make_site_name elem list
+    | Some "og:video" -> optprop (purl make_video) elem list
+    | Some "og:video:tag" ->
+      prop (fun x -> x |> make_video_tag |> make_video_metadata ) elem list
+    | Some str when  Str.string_match og_prefix str 0 ->
+      UnparsedMeta str :: list
+    | Some _ -> list
+    | None -> list
+
+  let parse_string content =
+    let soup = parse content in
+    let meta_tags = soup $$ "meta" in
+    let og_nodes = fold og_parser [] meta_tags in
+    List.rev og_nodes
+end

--- a/src/web/og.mli
+++ b/src/web/og.mli
@@ -1,0 +1,59 @@
+(** These data-structures are for holding meta-data
+    expressed by the {{:http://ogp.me/}open graph protocol}.
+
+    The basic information represented is the site name, title, content type,
+    canonical url and a preview image. If the content is music or video data,
+    additional data, additional data like tags or length may be present. Even
+    though the protocal requires a minimum information of title, type, image
+    and url, the webpage might be malformed. Parse.parse_string therefore just
+    returns a list of og_metadata.
+*)
+
+type url = { name : string }
+type locale = { language : string; territory : string }
+
+type og_type = TMusic | TVideo | TWebsite |
+               TArticle | TBook | TProfile | TOther of string
+type og_determiner = A | An | The | NoDet | Auto
+
+type og_video_metadata =
+  | VTag of string
+  | VDuration of int
+
+type og_metadata =
+  | Title of string | Type of og_type | Image of url | Url of url
+  | Audio of url | Description of string | Determiner of og_determiner
+  | Locale of locale | AlternateLocale of locale | SiteName of string
+  | Video of url | VideoMeta of og_video_metadata | UnparsedMeta of string
+
+type basic_metadata = { og_title : string;
+                        og_type  : og_type;
+                        og_image : url;
+                        og_url   : url
+                      }
+
+val parse_url : string -> url option
+val parse_locale : string -> locale option
+val parse_type  : string -> og_type
+
+val make_title : string -> og_metadata
+val make_type  : og_type -> og_metadata
+val make_image : url -> og_metadata
+val make_audio : url -> og_metadata
+val make_description : string -> og_metadata
+val make_determiner : og_determiner -> og_metadata
+val make_locale : locale -> og_metadata
+val make_alternate_locale : locale -> og_metadata
+val make_site_name : string -> og_metadata
+val make_video : url -> og_metadata
+val make_video_metadata : og_video_metadata -> og_metadata
+val make_url : url -> og_metadata
+
+val make_video_tag      : string -> og_video_metadata
+val make_video_duration : int -> og_video_metadata
+
+val format_metadata : Format.formatter -> og_metadata -> unit
+
+module Parser : sig
+  val parse_string : string -> og_metadata list
+end


### PR DESCRIPTION
The ```!yt``` command will now parse the og:* meta tags of the webpage and display title and description. As a fallback, it will use the html title.