### PR TITLE
Use `sequence` in opam

### DIFF
--- a/opam
+++ b/opam
@@ -28,6 +28,7 @@ depends: [
   "tls"
   "yojson"
   "containers"
+  "sequence"
   "ISO8601"
 ]
 depopts: [


### PR DESCRIPTION
It seems `sequence` is required in the latest version.