### PR TITLE
Small fix

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -44,7 +44,7 @@ Library "calculon_web"
   Install$:         flag(web)
   Modules:          Plugin_web, Og, Giphy_j, Giphy_t,
                     Plugin_movie, Movie_j, Movie_t, Movie_schema
-  BuildDepends:     calculon, atdgen, cohttp, lwt, cohttp.lwt, lambdasoup, uri
+  BuildDepends:     calculon, atdgen, cohttp, cohttp-lwt-unix, lwt, cohttp.lwt, lambdasoup, uri
 
 Executable "demo_bot"
   Path:             src/demo/

--- a/src/core/Plugin_factoids.ml
+++ b/src/core/Plugin_factoids.ml
@@ -273,11 +273,6 @@ type state = {
   actions: Plugin.action Signal.Send_ref.t;
 }
 
-let pick_list (l:'a list): 'a option = match l with
-  | [] -> None
-  | [message] -> Some message
-  | l -> Some (Rand_distrib.uniform l |> Rand_distrib.run)
-
 (* maximum size of returned lists *)
 let list_size_limit = 4
 


### PR DESCRIPTION
Here a small fix that remove a warning and add cohttp-lwt-unix in the dependency list of calculon_web.