### PR TITLE
add custom prefix for command

### DIFF
--- a/src/core/Command.mli
+++ b/src/core/Command.mli
@@ -29,7 +29,7 @@ type t = {
   descr: string; (* for !help *)
 }
 
-val match_prefix1 : prefix:string -> Core.privmsg -> string option
+val match_prefix1 : ?prefix:string -> cmd:string -> Core.privmsg -> string option
 (** [match_prefix1 ~prefix:"foo" msg]
 
     - if [msg="!foo bar"], returns [Some bar]
@@ -40,7 +40,7 @@ val extract_hl : string -> (string * string) option
 (** [extract_hl "foo > bar"] returns [Some ("foo", "bar")].
     Returns [None] if it cannot split on ">" cleanly. *)
 
-val match_prefix1_full : prefix:string -> Core.privmsg -> (string * string option) option
+val match_prefix1_full : ?prefix:string -> cmd:string -> Core.privmsg -> (string * string option) option
 (* @returns [Some (msg, hl)] if [msg] matches the regex,
    and [hl] is either [Some foo] if the message ended with "> hl",
    [None] otherwise *)
@@ -59,7 +59,8 @@ exception Fail of string
 val make_simple :
   ?descr:string ->
   ?prio:int ->
-  prefix:string ->
+  ?prefix:string ->
+  cmd:string ->
   (Core.privmsg -> string -> string option Lwt.t) ->
   t
 (** [make_simple ~pre f] matches messages of the form "!pre xxx",
@@ -69,7 +70,8 @@ val make_simple :
 val make_simple_l :
   ?descr:string ->
   ?prio:int ->
-  prefix:string ->
+  ?prefix:string ->
+  cmd:string ->
   (Core.privmsg -> string -> string list Lwt.t) ->
   t
 (** Same as {!make_simple} but replies lines
@@ -78,7 +80,8 @@ val make_simple_l :
 val make_simple_query_l :
   ?descr:string ->
   ?prio:int ->
-  prefix:string ->
+  ?prefix:string ->
+  cmd:string ->
   (Core.privmsg -> string -> string list Lwt.t) ->
   t
 (** Same as {!make_simple_l} but replies lines in query (private)

--- a/src/core/Plugin_factoids.ml
+++ b/src/core/Plugin_factoids.ml
@@ -316,7 +316,7 @@ let search_tokenize s =
   |> Re.split (Re.Perl.compile_pat "[ \t]+")
 
 let cmd_search state =
-  Command.make_simple_l ~descr:"search in factoids" ~prefix:"search" ~prio:10
+  Command.make_simple_l ~descr:"search in factoids" ~prefix:"!" ~cmd:"search" ~prio:10
     (fun _ s ->
        let tokens = search_tokenize s in
        search tokens state.st_cur
@@ -328,7 +328,7 @@ let cmd_search state =
 let cmd_search_all state =
   Command.make_simple_query_l
     ~descr:"search all matches in factoids (reply in pv)"
-    ~prefix:"search_all" ~prio:10
+    ~prefix:"!" ~cmd:"search_all" ~prio:10
     (fun _ s ->
        let tokens = search_tokenize s in
        search tokens state.st_cur
@@ -337,7 +337,7 @@ let cmd_search_all state =
     )
 
 let cmd_see state =
-  Command.make_simple_l ~descr:"see a factoid's content" ~prefix:"see" ~prio:10
+  Command.make_simple_l ~descr:"see a factoid's content" ~prefix:"!" ~cmd:"see" ~prio:10
     (fun _ s ->
        let v = get (mk_key s) state.st_cur in
        let msg = match v with
@@ -351,7 +351,8 @@ let cmd_see state =
 let cmd_see_all state =
   Command.make_simple_query_l
     ~descr:"see all of a factoid's content (in pv)"
-    ~prefix:"see_all"
+    ~prefix:"!"
+    ~cmd:"see_all"
     ~prio:10
     (fun _ s ->
        let v = get (mk_key s) state.st_cur in
@@ -364,7 +365,7 @@ let cmd_see_all state =
     )
 
 let cmd_random state =
-  Command.make_simple ~descr:"random factoid" ~prefix:"random" ~prio:10
+  Command.make_simple ~descr:"random factoid" ~prefix:"!" ~cmd:"random" ~prio:10
     (fun _ _ ->
        let msg = random state.st_cur in
        Some msg |> Lwt.return

--- a/src/core/Plugin_history.ml
+++ b/src/core/Plugin_history.ml
@@ -51,7 +51,8 @@ let cmd_history st =
     ~descr:(Printf.sprintf
         "give back <n> lines of history in query (max %d)" st.size)
     ~prio:10
-    ~prefix:"history"
+    ~prefix:"!"
+    ~cmd:"history"
     (fun _ msg ->
        let msg = String.trim msg in
        if msg="" then Lwt.return (reply_history st st.default_len)

--- a/src/core/Plugin_social.ml
+++ b/src/core/Plugin_social.ml
@@ -102,7 +102,7 @@ let cmd_tell_inner ~at state =
   Command.make_simple
     ~descr:("ask the bot to transmit a message to someone absent\n"
       ^ if at then "format: <date> <nick> <msg>" else "format: <nick> <msg>")
-    ~prio:10 ~prefix:(if at then "tell_at" else "tell")
+    ~prio:10 ~prefix:"!" ~cmd:(if at then "tell_at" else "tell")
     (fun msg s ->
        let nick = msg.Core.nick in
        let target = Core.reply_to msg in
@@ -160,7 +160,7 @@ let create_message_for_user now (user,last) =
 let cmd_seen (state:state) =
   Command.make_simple_l
     ~descr:"ask for the last time someone talked on this chan"
-    ~prio:10 ~prefix:"seen"
+    ~prio:10 ~prefix:"!" ~cmd:"seen"
     (fun _msg s ->
        try
          let dest = CCString.trim s |> CCString.uppercase_ascii in
@@ -182,7 +182,7 @@ let cmd_seen (state:state) =
 let cmd_last (state:state) =
   Command.make_simple_l
     ~descr:"ask for the last n people talking on this chan (default: n=3)"
-    ~prio:10 ~prefix:"last"
+    ~prio:10 ~prefix:"!" ~cmd:"last"
     (fun msg s ->
        try
          let default_n = 3 in
@@ -212,10 +212,10 @@ let cmd_last (state:state) =
        with e ->
          Lwt.fail (Command.Fail ("last_seen: " ^ Printexc.to_string e)))
 
-let cmd_ignore_template ~prefix prefix_stem ignore (state:state) =
+let cmd_ignore_template ~cmd prefix_stem ignore (state:state) =
   Command.make_simple
-    ~descr:(prefix ^ " nick")
-    ~prio:10 ~prefix
+    ~descr:(cmd ^ " nick")
+    ~prio:10 ~prefix:"!" ~cmd
     (fun _ s ->
        try
          let dest = String.trim s in
@@ -234,15 +234,15 @@ let cmd_ignore_template ~prefix prefix_stem ignore (state:state) =
            in
            Lwt.return msg )
        with e ->
-         Lwt.fail (Command.Fail (prefix ^ ": " ^ Printexc.to_string e)))
+         Lwt.fail (Command.Fail (cmd ^ ": " ^ Printexc.to_string e)))
 
-let cmd_ignore = cmd_ignore_template ~prefix:"ignore" "ignor" true
-let cmd_unignore = cmd_ignore_template ~prefix:"unignore" "unignor" false
+let cmd_ignore = cmd_ignore_template ~cmd:"ignore" "ignor" true
+let cmd_unignore = cmd_ignore_template ~cmd:"unignore" "unignor" false
 
 let cmd_ignore_list (state:state) =
   Command.make_simple_l
     ~descr:"add nick to list of ignored people"
-    ~prio:10 ~prefix:"ignore_list"
+    ~prio:10 ~prefix:"!" ~cmd:"ignore_list"
     (fun _ _ ->
        try
          Log.logf "query: ignore_list";

--- a/src/core/Plugin_state.ml
+++ b/src/core/Plugin_state.ml
@@ -10,7 +10,8 @@ let cmd_reload st =
   Command.make_simple
     ~descr:"reload state from disk"
     ~prio:10
-    ~prefix:"reload"
+    ~prefix:"!"
+    ~cmd:"reload"
     (fun _ _ ->
        Signal.Send_ref.send st.actions Plugin.Require_reload >|= fun () ->
        Some (Talk.select Talk.Ack)
@@ -21,7 +22,8 @@ let cmd_save st =
   Command.make_simple
     ~descr:"save state to disk"
     ~prio:10
-    ~prefix:"save"
+    ~prefix:"!"
+    ~cmd:"save"
     (fun _ _ ->
        Signal.Send_ref.send st.actions Plugin.Require_save >|= fun () ->
        Some (Talk.select Talk.Ack)

--- a/src/core/Plugin_vote.ml
+++ b/src/core/Plugin_vote.ml
@@ -207,7 +207,7 @@ let reply polls msg s =
 let cmd_vote state : Command.t =
   Command.make_simple
     ~descr:("vote system for yes/no questions\n" ^ help)
-    ~prefix:"vote" ~prio:10
+    ~prefix:"!" ~cmd:"vote" ~prio:10
     (reply state)
 
 let of_json _ _ : state Lwt_err.t =

--- a/src/extras/Plugin_markcough.ml
+++ b/src/extras/Plugin_markcough.ml
@@ -274,7 +274,7 @@ type state = {
 
 let cmd_markov (state:state): Command.t =
   Command.make_simple
-    ~descr:"generate random chains" ~prio:15 ~prefix:"markcough"
+    ~descr:"generate random chains" ~prio:15 ~prefix:"!" ~cmd:"markcough"
     (fun _ msg ->
        let msg = String.trim msg in
        let author = if msg="" then None else Some msg in

--- a/src/web/Plugin_movie.ml
+++ b/src/web/Plugin_movie.ml
@@ -98,9 +98,9 @@ let format_seq ?n results =
   CCList.map (show_result ~buffer) |>
   Lwt.return
 
-let mk_movie_cmd prefix q_of_str =
+let mk_movie_cmd prefix cmd q_of_str =
   Command.make_simple_l
-    ~descr:"look for movies/series" ~prio:10 ~prefix
+    ~descr:"look for movies/series" ~prio:10 ?prefix ~cmd
     (fun _ s ->
        String.trim s |>
        q_of_str |>
@@ -108,8 +108,8 @@ let mk_movie_cmd prefix q_of_str =
        format_seq
     )
 
-let cmd_film = mk_movie_cmd "film" query_movie
-let cmd_serie = mk_movie_cmd "serie" query_serie
+let cmd_film = mk_movie_cmd (Some "!") "film" query_movie
+let cmd_serie = mk_movie_cmd (Some "!") "serie" query_serie
 
 let plugin =
   [ cmd_film;

--- a/src/web/Plugin_web.ml
+++ b/src/web/Plugin_web.ml
@@ -48,7 +48,7 @@ let youtube_hosts = [
 
 let cmd_yt =
   Command.make_simple
-    ~prio:10 ~prefix:"yt" ~descr:"lookup description of given youtube URL"
+    ~prio:10 ~prefix:"!" ~cmd:"yt" ~descr:"lookup description of given youtube URL"
     (fun _ s ->
        let uri = Uri.of_string (String.trim s) in
        match Uri.host uri with
@@ -75,7 +75,7 @@ let get_youtube_search (query:string): string Lwt.t =
 
 let cmd_yt_search =
   Command.make_simple_l
-    ~prio:10 ~prefix:"yt_search" ~descr:"lookup on youtube"
+    ~prio:10 ~prefix:"!" ~cmd:"yt_search" ~descr:"lookup on youtube"
     (fun _ s ->
        (get_youtube_search (String.trim s) >|= fun body ->
         find_yt_ids ~n:1 body)
@@ -137,7 +137,7 @@ module Giphy = struct
 
   let cmd =
     Command.make_simple
-      ~prio:10 ~prefix:"giphy" ~descr:"lookup on giphy (Powered by Giphy)"
+      ~prio:10 ~prefix:"!" ~cmd:"giphy" ~descr:"lookup on giphy (Powered by Giphy)"
       (fun _ s ->
          let s = String.trim s in
          if s=""


### PR DESCRIPTION
prefix argument become the custom prefix for command
cmd replace prefix as the name of the command
For example in the command !plop, prefix = "!" and cmd = "plop"

/!\ break backward compatibility