### PR TITLE
TLS client cert support

### DIFF
--- a/src/core/Config.ml
+++ b/src/core/Config.ml
@@ -13,6 +13,7 @@ type t = {
   realname : string;
   nick : string;
   tls: bool;
+  tls_cert : Tls.Config.certchain option;
   channel : string;
   state_file : string;
   irc_log: irc_log; (* log IRC events *)
@@ -25,6 +26,7 @@ let default = {
   realname = "calculon";
   nick = "calculon";
   tls = true;
+  tls_cert = None;
   channel = "#ocaml";
   state_file = "state.json";
   irc_log = `None;

--- a/src/core/Config.mli
+++ b/src/core/Config.mli
@@ -13,6 +13,7 @@ type t = {
   realname : string;
   nick : string;
   tls: bool;
+  tls_cert : Tls.Config.certchain option;
   channel : string;
   state_file : string; (* where plugins' state is stored *)
   irc_log: irc_log; (* log IRC events *)

--- a/src/core/Core.ml
+++ b/src/core/Core.ml
@@ -241,10 +241,18 @@ let run conf ~init () =
   in
   if conf.C.tls
   then (
+    let certificates = match conf.C.tls_cert with
+      | Some certchain -> `Single certchain
+      | None -> `None in
+    let tls_config =
+      Tls.Config.client
+        ~authenticator:X509.Authenticator.null
+        ~certificates
+        () in
     let connect () =
       Irc_client_tls.connect_by_name
         ~username:conf.C.username ~realname:conf.C.realname ~nick:conf.C.nick
-        ~server:conf.C.server ~port:conf.C.port
+        ~server:conf.C.server ~port:conf.C.port ~config:tls_config
         ()
     in
     loop_tls ~connect ~init ()


### PR DESCRIPTION
This adds client certificate support. This is convenient when authenticating to e.g. Freenode.

I have not added anything to `Config.parse` to set this option since it would likely require reading the certificate and key from files which I'm not sure where you would want to do that.

Note that it uses `X509.Authenticator.null` as is the default in `irc-client`. There is therefore no checks of the server certificate.