### PR TITLE
Prefix cmd

### DIFF
--- a/src/core/Command.ml
+++ b/src/core/Command.ml
@@ -95,8 +95,8 @@ let make_simple ?descr ?prio ?prefix ~cmd f : t =
 let compare_prio c1 c2 = compare c1.prio c2.prio
 
 (* help command *)
-let cmd_help (l:t list): t =
-  make_simple ~descr:"help message" ~cmd:"help" ~prio:5
+let cmd_help ~prefix (l:t list): t =
+  make_simple ~descr:"help message" ~prefix  ~cmd:"help" ~prio:5
     (fun _ s ->
        let s = String.trim s in
        let res =
@@ -104,7 +104,7 @@ let cmd_help (l:t list): t =
          then
            let l = List.map (fun c -> c.name) l in
            let message =
-             "!help: commands are " ^ Prelude.string_list_to_string l
+             prefix ^ "help: commands are " ^ Prelude.string_list_to_string l
            in
            Some message
          else
@@ -135,4 +135,4 @@ let run core l msg : unit Lwt.t =
           aux tail
       end
   in
-  aux (cmd_help l :: l)
+  aux l

--- a/src/core/Command.mli
+++ b/src/core/Command.mli
@@ -29,7 +29,7 @@ type t = {
   descr: string; (* for !help *)
 }
 
-val match_prefix1 : ?prefix:string -> cmd:string -> Core.privmsg -> string option
+val match_prefix1 : prefix:string -> cmd:string -> Core.privmsg -> string option
 (** [match_prefix1 ~prefix:"foo" msg]
 
     - if [msg="!foo bar"], returns [Some bar]
@@ -40,7 +40,7 @@ val extract_hl : string -> (string * string) option
 (** [extract_hl "foo > bar"] returns [Some ("foo", "bar")].
     Returns [None] if it cannot split on ">" cleanly. *)
 
-val match_prefix1_full : ?prefix:string -> cmd:string -> Core.privmsg -> (string * string option) option
+val match_prefix1_full : prefix:string -> cmd:string -> Core.privmsg -> (string * string option) option
 (* @returns [Some (msg, hl)] if [msg] matches the regex,
    and [hl] is either [Some foo] if the message ended with "> hl",
    [None] otherwise *)

--- a/src/core/Command.mli
+++ b/src/core/Command.mli
@@ -90,6 +90,13 @@ val make_simple_query_l :
 val compare_prio : t -> t -> int
 (** Compare by priority. Used to sort a list of commands by their priority. *)
 
+val cmd_help :
+  prefix:string ->
+  t list ->
+  t
+(** [cmd_help ~prefix l] build a command [\[prefix\]help] that print a help
+    message about the plugin in l. *)
+
 val run : Core.t -> t list -> Core.privmsg -> unit Lwt.t
 (** Execute the commands, in given order, on the message. First command
     to succeed shortcuts the other ones. *)

--- a/src/core/Command.mli
+++ b/src/core/Command.mli
@@ -95,7 +95,7 @@ val cmd_help :
   t list ->
   t
 (** [cmd_help ~prefix l] build a command [\[prefix\]help] that print a help
-    message about the plugin in l. *)
+    message about plugins in l. *)
 
 val run : Core.t -> t list -> Core.privmsg -> unit Lwt.t
 (** Execute the commands, in given order, on the message. First command

--- a/src/core/Plugin.ml
+++ b/src/core/Plugin.ml
@@ -38,10 +38,10 @@ type t =
 
 type plugin = t
 
-let of_cmd c = Stateless [c]
-let of_cmds l =
+let of_cmd ?(prefix="!") c = Stateless [Command.cmd_help ~prefix [c];c]
+let of_cmds ?(prefix="!") l =
   if l=[] then invalid_arg "Plugin.of_cmds";
-  Stateless l
+  Stateless (Command.cmd_help ~prefix l::l)
 
 let stateful
     ~name

--- a/src/core/Plugin.mli
+++ b/src/core/Plugin.mli
@@ -43,10 +43,14 @@ type t =
 type plugin = t
 
 val of_cmd : ?prefix:string -> Command.t -> t
-(** Stateless plugin with 1 command *)
+(** Stateless plugin with 1 command. [of_cmd] include automatically a help
+    command. The optional argument [prefix] define the prefix of the help
+    command which is [!] by default. *)
 
 val of_cmds : ?prefix:string -> Command.t list -> t
-(** Stateless plugin with several commands
+(** Stateless plugin with several commands. [of_cmd] include automatically a help
+    command. The optional argument [prefix] define the prefix of the help
+    command which is [!] by default.
     @raise Invalid_argument if the list is empty *)
 
 val stateful :

--- a/src/core/Plugin.mli
+++ b/src/core/Plugin.mli
@@ -42,10 +42,10 @@ type t =
 
 type plugin = t
 
-val of_cmd : Command.t -> t
+val of_cmd : ?prefix:string -> Command.t -> t
 (** Stateless plugin with 1 command *)
 
-val of_cmds : Command.t list -> t
+val of_cmds : ?prefix:string -> Command.t list -> t
 (** Stateless plugin with several commands
     @raise Invalid_argument if the list is empty *)
 


### PR DESCRIPTION
Expose the cmd_help in Command.mli
Add the help command in Plugin.of_cnd and Plugin.of_cmds instead of Command.run.
Add the prefix in the description of a command.
Possibility to change the prefix of the command help by adding an optional argument to Plugin.of_cmd and Plugin.of_cmds.