### PR TITLE
Factoids: single line search-all

### DIFF
--- a/src/core/Plugin_factoids.ml
+++ b/src/core/Plugin_factoids.ml
@@ -332,7 +332,7 @@ let cmd_search_all state =
        let tokens = search_tokenize s in
        search tokens state.st_cur
        |> insert_noresult
-       |> String.concat " | "
+       |> (fun l -> if List.length l > 5 then [String.concat " | " l] else l)
        |> Lwt.return
     )
 

--- a/src/core/Plugin_factoids.ml
+++ b/src/core/Plugin_factoids.ml
@@ -332,6 +332,7 @@ let cmd_search_all state =
        let tokens = search_tokenize s in
        search tokens state.st_cur
        |> insert_noresult
+       |> String.concat " | "
        |> Lwt.return
     )
 
@@ -480,3 +481,4 @@ let plugin : Plugin.t =
   Plugin.stateful
     ~name:"factoids" ~to_json ~of_json ~commands
     ~stop:(fun _ -> Lwt.return_unit) ()
+


### PR DESCRIPTION
Current search-all lists all entries on several lines, but show only 10 of them, probably because of a limit from freenode server

This should help by keeping entries on the same line