### PR TITLE
Remove tls_cert config option

### DIFF
--- a/src/core/Config.ml
+++ b/src/core/Config.ml
@@ -8,7 +8,6 @@ type t = {
   realname : string;
   nick : string;
   tls: bool;
-  tls_cert : Ssl.certificate option;
   sasl: bool;
   channel : string;
   state_file : string;
@@ -24,7 +23,6 @@ let default = {
   realname = "calculon";
   nick = "calculon";
   tls = true;
-  tls_cert = None;
   sasl = true;
   channel = "#ocaml";
   state_file = "state.json";

--- a/src/core/Config.mli
+++ b/src/core/Config.mli
@@ -8,7 +8,6 @@ type t = {
   realname : string;
   nick : string;
   tls: bool;
-  tls_cert : Ssl.certificate option;
   sasl: bool;
   channel : string; (** Channel to join after the connexion to the server *)
   state_file : string; (** Where plugins' state is stored *)
@@ -29,7 +28,6 @@ val default : t
 - password = None
 - nick = "calculon"
 - tls = true
-- tls_cert = None
 - sasl = true
 - channel = "#ocaml"
 - state_file = "state.json"


### PR DESCRIPTION
Support for client certificates disappeared when migrating to ocaml-ssl
in 7d8213ff194c8989ea8cdd15ab12bc945236f723.

Can I also ask why ocaml-ssl was chosen instead?